### PR TITLE
Allow flag to bypass required IP check when creating device

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -156,7 +156,7 @@ func (c *Client) getdevices(url string) ([]*Device, error) {
 
 func (c *Client) CreateDeviceAndSite(siteDevCreate *SiteAndDeviceCreate) (*Device, error) {
 
-	if len(siteDevCreate.Device.IPs) == 0 {
+	if !siteDevCreate.Device.AllowNoIP && len(siteDevCreate.Device.IPs) == 0 {
 		return nil, fmt.Errorf("Missing IP for device")
 	}
 
@@ -194,7 +194,7 @@ func (c *Client) CreateDeviceAndSite(siteDevCreate *SiteAndDeviceCreate) (*Devic
 func (c *Client) CreateDevice(create *DeviceCreate) (*Device, error) {
 	url := fmt.Sprintf(c.deviceURL, "")
 
-	if len(create.IPs) == 0 {
+	if !create.AllowNoIP && len(create.IPs) == 0 {
 		return nil, fmt.Errorf("Missing IP for device")
 	}
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -115,6 +115,104 @@ func TestCreateDevice(t *testing.T) {
 	assert.EqualValues(create.CdnAttr, device.CdnAttr)
 }
 
+func TestCreateDeviceFailsWithoutIPFlag(t *testing.T) {
+	client, _, _, err := test.NewClientServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert := assert.New(t)
+
+	create := &api.DeviceCreate{
+		Name:        test.RandStr(8),
+		Type:        test.RandStr(8),
+		Description: test.RandStr(8),
+		SampleRate:  int(rand.Uint32()),
+		BgpType:     test.RandStr(4),
+		PlanID:      int(rand.Uint32()),
+		IPs:         []net.IP{},
+		CdnAttr:     test.RandStr(1),
+	}
+
+	_, err = client.CreateDevice(create)
+	assert.Error(err)
+}
+
+func TestCreateDeviceWithoutIP(t *testing.T) {
+	client, _, _, err := test.NewClientServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert := assert.New(t)
+
+	create := &api.DeviceCreate{
+		Name:        test.RandStr(8),
+		Type:        test.RandStr(8),
+		Description: test.RandStr(8),
+		SampleRate:  int(rand.Uint32()),
+		BgpType:     test.RandStr(4),
+		PlanID:      int(rand.Uint32()),
+		IPs:         []net.IP{},
+		AllowNoIP:   true,
+		CdnAttr:     test.RandStr(1),
+	}
+
+	device, err := client.CreateDevice(create)
+	assert.NoError(err)
+
+	assert.EqualValues(create.Name, device.Name)
+	assert.EqualValues(create.Type, device.Type)
+	assert.EqualValues(create.Description, device.Description)
+	assert.EqualValues(net.IP(nil), device.IP)
+	assert.EqualValues(create.SampleRate, device.SampleRate)
+	assert.EqualValues(create.BgpType, device.BgpType)
+	assert.EqualValues(create.PlanID, int(device.Plan.ID))
+	assert.EqualValues(create.CdnAttr, device.CdnAttr)
+}
+
+func TestCreateDeviceAndSiteWithoutIP(t *testing.T) {
+	client, _, _, err := test.NewClientServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert := assert.New(t)
+
+	create := &api.DeviceCreate{
+		Name:        test.RandStr(8),
+		Type:        test.RandStr(8),
+		Description: test.RandStr(8),
+		SampleRate:  int(rand.Uint32()),
+		BgpType:     test.RandStr(4),
+		PlanID:      int(rand.Uint32()),
+		IPs:         []net.IP{},
+		AllowNoIP:   true,
+		CdnAttr:     test.RandStr(1),
+	}
+
+	siteCreate := &api.SiteCreate{
+		Title:   "Hawaii Offsite",
+		City:    "Honolulu",
+		Region:  "Pacific",
+		Country: "USA",
+	}
+
+	siteAndDeviceCreate := &api.SiteAndDeviceCreate{
+		Site:   siteCreate,
+		Device: create,
+	}
+
+	device, err := client.CreateDeviceAndSite(siteAndDeviceCreate)
+	assert.NoError(err)
+
+	assert.EqualValues(siteAndDeviceCreate.Device.Name, device.Name)
+	assert.EqualValues(siteAndDeviceCreate.Device.Type, device.Type)
+	assert.EqualValues(siteAndDeviceCreate.Device.Description, device.Description)
+	assert.EqualValues(net.IP(nil), device.IP)
+	assert.EqualValues(siteAndDeviceCreate.Device.SampleRate, device.SampleRate)
+	assert.EqualValues(siteAndDeviceCreate.Device.BgpType, device.BgpType)
+	assert.EqualValues(siteAndDeviceCreate.Device.PlanID, int(device.Plan.ID))
+	assert.EqualValues(siteAndDeviceCreate.Device.CdnAttr, device.CdnAttr)
+}
+
 func TestGetAllDevices(t *testing.T) {
 	client, _, device, err := test.NewClientServer()
 	if err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -54,6 +54,7 @@ type DeviceCreate struct {
 	PlanID      int      `json:"plan_id,omitempty"`
 	SiteID      int      `json:"site_id,omitempty"`
 	IPs         []net.IP `json:"sending_ips"`
+	AllowNoIP   bool     `json:"-"`
 	CdnAttr     string   `json:"cdn_attr"`
 	ExportId    int      `json:"cloud_export_id,omitempty"`
 	Subtype     string   `json:"device_subtype"`


### PR DESCRIPTION
Adds a client-side flag within the creation of a device about whether or not to allow creation of devices without an IP address. To keep backwards compatibility, this is `false` but default, meaning that if someone tries to create a device but does not provide an IP address, the code will return an error (like it works prior to this PR).