### PR TITLE
Adds in options for filtering which devices are returned and what the results are augmented with

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -70,6 +70,14 @@ type AllDeviceWrapper struct {
 	Devices []*Device `json:"devices"`
 }
 
+type DevicesFilter struct {
+	FilterCloud bool     `schema:"filterCloud"`
+	CloudOnly   bool     `schema:"cloudOnly"`
+	Subtypes    []string `schema:"subtypes"`
+	AugmentWith []string `schema:"augmentWith"`
+	Columns     []string `schema:"columns"`
+}
+
 type Interface struct {
 	ID      uint64 `json:"id,string"`
 	Index   uint64 `json:"snmp_id,string"`


### PR DESCRIPTION
Based on updates to our internal API in https://github.com/kentik/chnode_v2/pull/1460 for getting devices, this adds a new struct and function to allow more options for filtering and augmenting the devices list.

I couldn't re-use existing query parameter building (i.e. `url.Values`) because it would escape the key that is desired to have a suffix of `[]` to ensure it can be properly interpreted as an array. I did follow the general pattern of how this was implemented as part of `Encode()` (https://cs.opensource.google/go/go/+/master:src/net/url/url.go;l=954-977;drc=4d8db00641cc9ff4f44de7df9b8c4f4a4f9416ee)

I did some testing of this manually since the API has already been updated and the improvements that we will likely see in transfluo should be really good. For example, our worst customer is 2273 (Uber) normally with 4244 devices (and a lot of interfaces) would take ~40-50 seconds to return based on our grafana metrics. After testing this locally, it now takes less than a second.