### PR TITLE
Support passing in external loggers to retryable client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type Client struct {
@@ -32,6 +32,8 @@ type ClientConfig struct {
 	Retries int
 	API     *url.URL
 	Proxy   *url.URL
+
+	Logger interface{}
 }
 
 type ExportStatus struct {
@@ -65,6 +67,7 @@ func NewClient(config ClientConfig) *Client {
 	retryClient.HTTPClient.Transport = transport
 	retryClient.RetryWaitMin = config.Timeout
 	retryClient.RetryMax = config.Retries
+	retryClient.Logger = config.Logger
 
 	client := retryClient.StandardClient() // *http.Client
 

--- a/cmd/demo/main_test.go
+++ b/cmd/demo/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kentik/libkflow"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubLogger struct {
+	count uint32
+}
+
+func (s *stubLogger) Printf(string, ...interface{}) { atomic.AddUint32(&s.count, 1) }
+
+type stubLeveledLogger struct {
+	count uint32
+}
+
+func (s *stubLeveledLogger) Error(string, ...interface{}) { atomic.AddUint32(&s.count, 1) }
+func (s *stubLeveledLogger) Info(string, ...interface{})  { atomic.AddUint32(&s.count, 1) }
+func (s *stubLeveledLogger) Debug(string, ...interface{}) { atomic.AddUint32(&s.count, 1) }
+func (s *stubLeveledLogger) Warn(string, ...interface{})  { atomic.AddUint32(&s.count, 1) }
+
+func TestSettingLogger(t *testing.T) {
+	// configuration here should not match an actual running server, but instead intentionally be down to verify logging
+	var (
+		email    = "test@example.com"
+		token    = "token"
+		deviceID = 1
+		host     = net.ParseIP("127.0.0.1")
+		port     = 8999
+		program  = "demo"
+		version  = "0.0.1"
+	)
+	errors := make(chan error, 100)
+
+	config := libkflow.NewConfig(email, token, program, version)
+	config.SetServer(host, port)
+	config.SetRetries(1)
+	config.SetVerbose(1)
+	config.SetTimeout(0)
+
+	l := stubLogger{}
+	config.SetLogger(&l)
+
+	// Performing the call, regardless of success, should result in logging internally
+	_, _ = libkflow.NewSenderWithDeviceID(deviceID, errors, config)
+	assert.True(t, l.count > 0)
+}
+func TestSettingLeveledLogger(t *testing.T) {
+	// configuration here should not match an actual running server, but instead intentionally be down to verify logging
+	var (
+		email    = "test@example.com"
+		token    = "token"
+		deviceID = 1
+		host     = net.ParseIP("127.0.0.1")
+		port     = 8999
+		program  = "demo"
+		version  = "0.0.1"
+	)
+	errors := make(chan error, 100)
+
+	config := libkflow.NewConfig(email, token, program, version)
+	config.SetServer(host, port)
+	config.SetRetries(1)
+	config.SetVerbose(1)
+	config.SetTimeout(0)
+
+	l := stubLeveledLogger{}
+	config.SetLeveledLogger(&l)
+
+	// Performing the call, regardless of success, should result in logging internally
+	_, _ = libkflow.NewSenderWithDeviceID(deviceID, errors, config)
+	assert.True(t, l.count > 0)
+}


### PR DESCRIPTION
Allows users to pass in a standard logger or leveled logger to the configuration. This is crucial when setting up a client with retries, since otherwise it logs to stderr by default. Setting this to `nil` is allowed and will suppress the stderr logs.

One thing to note about the leveled logger is it is with an expected 'structured' leveled approach. I.e. will pass in something like
```go
v.Debug("performing request", "method", req.Method, "url", req.URL)
```