### PR TITLE
Adjusts metrics format to remove cid/did from name and move it into extra tags

### DIFF
--- a/config.go
+++ b/config.go
@@ -130,7 +130,7 @@ func (c *Config) OverrideURLs(api, flow, metrics *url.URL) {
 }
 
 func (c *Config) NewMetrics(dev *api.Device) *metrics.Metrics {
-	return metrics.New(dev.ClientID(), c.program, c.version)
+	return metrics.New(dev.CompanyID, dev.ID, c.program, c.version)
 }
 
 func (c *Config) GetClient() *api.Client {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"fmt"
 	"net/url"
-	"strings"
+	"strconv"
 	"time"
 
 	"github.com/kentik/kit/go/legacy/common/cmetrics"
@@ -26,11 +26,9 @@ type Metrics struct {
 	Extra          map[string]string
 }
 
-func New(clientid, program, version string) *Metrics {
-	clientid = strings.Replace(clientid, ":", ".", -1)
-
+func New(companyID int, deviceID int, program, version string) *Metrics {
 	name := func(key string) string {
-		return fmt.Sprintf("client_%s.%s", key, clientid)
+		return fmt.Sprintf("client_%s", key)
 	}
 
 	sample := func() metrics.Sample {
@@ -42,6 +40,8 @@ func New(clientid, program, version string) *Metrics {
 		"ft":    program,
 		"dt":    "libkflow",
 		"level": "primary",
+		"cid":   strconv.Itoa(companyID),
+		"did":   strconv.Itoa(deviceID),
 	}
 
 	// libkflow creates its own go-metrics Registry, which hold only its

--- a/send_test.go
+++ b/send_test.go
@@ -90,7 +90,7 @@ func BenchmarkSenderSend(b *testing.B) {
 }
 
 func setup(t testing.TB) (*Sender, *test.Server, *assert.Assertions) {
-	metrics := metrics.New("clientid", "send_test", "1.0.0")
+	metrics := metrics.New(100, 200, "send_test", "1.0.0")
 	agg, err := agg.NewAgg(10*time.Millisecond, 100, metrics)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Rather than using the indirection of the "client id" then remapping it to a dot separated id consisting of company id, device name, and device id this just directly passes in the company id and device id as tags/extra values. This simplifies the approach and adheres to internal standards/best practices of how these internal metrics should be reported to Kentik.

This was validated via internal, manual testing.