### PR TITLE
Adds a 'BytesSent' client metric and allows setting the metrics prefix

### DIFF
--- a/agg/agg_test.go
+++ b/agg/agg_test.go
@@ -71,6 +71,7 @@ func setup(t *testing.T, interval time.Duration, fps int) (*testState, *assert.A
 		OrigSampleRate: metrics.NewHistogram(metrics.NewUniformSample(100)),
 		NewSampleRate:  metrics.NewHistogram(metrics.NewUniformSample(100)),
 		RateLimitDrops: metrics.NewMeter(),
+		BytesSent:      metrics.NewMeter(),
 	}
 
 	agg, err := NewAgg(interval, fps, metrics)

--- a/config.go
+++ b/config.go
@@ -17,19 +17,21 @@ import (
 
 // Config describes the libkflow configuration.
 type Config struct {
-	email           string
-	token           string
-	capture         Capture
-	proxy           *url.URL
-	api             *url.URL
-	flow            *url.URL
-	metrics         *url.URL
-	sample          int
-	timeout         time.Duration
-	retries         int
-	logger          interface{}
-	program         string
-	version         string
+	email   string
+	token   string
+	capture Capture
+	proxy   *url.URL
+	api     *url.URL
+	flow    *url.URL
+	metrics *url.URL
+	sample  int
+	timeout time.Duration
+	retries int
+	logger  interface{}
+	program string
+	version string
+
+	metricsPrefix   string
 	metricsInterval time.Duration
 }
 
@@ -137,6 +139,10 @@ func (c *Config) GetClient() *api.Client {
 	return c.client()
 }
 
+func (c *Config) SetMetricsPrefix(prefix string) {
+	c.metricsPrefix = prefix
+}
+
 func (c *Config) SetMetricsInterval(dur time.Duration) {
 	c.metricsInterval = dur
 }
@@ -159,7 +165,7 @@ func (c *Config) start(client *api.Client, dev *api.Device, errors chan<- error)
 		c.metricsInterval = 60 * time.Second
 	}
 	metrics := c.NewMetrics(dev)
-	metrics.Start(c.metrics.String(), c.email, c.token, c.metricsInterval, c.proxy)
+	metrics.Start(c.metrics.String(), c.email, c.token, c.metricsPrefix, c.metricsInterval, c.proxy)
 
 	agg, err := agg.NewAgg(time.Second, dev.MaxFlowRate, metrics)
 	if err != nil {
@@ -192,18 +198,19 @@ func (c *Config) start(client *api.Client, dev *api.Device, errors chan<- error)
 
 func defaultConfig(email, token, program, version string) *Config {
 	return &Config{
-		email:   email,
-		token:   token,
-		capture: Capture{},
-		proxy:   nil,
-		api:     parseURL("https://api.kentik.com/api/internal"),
-		flow:    parseURL("https://flow.kentik.com/chf"),
-		metrics: parseURL("https://flow.kentik.com/tsdb"),
-		timeout: 10 * time.Second,
-		retries: 0,
-		logger:  go_log.New(os.Stderr, "", go_log.LstdFlags), // default behavior of underlying logger
-		program: program,
-		version: version,
+		email:         email,
+		token:         token,
+		capture:       Capture{},
+		proxy:         nil,
+		api:           parseURL("https://api.kentik.com/api/internal"),
+		flow:          parseURL("https://flow.kentik.com/chf"),
+		metrics:       parseURL("https://flow.kentik.com/tsdb"),
+		timeout:       10 * time.Second,
+		retries:       0,
+		logger:        go_log.New(os.Stderr, "", go_log.LstdFlags), // default behavior of underlying logger
+		program:       program,
+		version:       version,
+		metricsPrefix: "chf",
 	}
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,6 +23,7 @@ type Metrics struct {
 	OrigSampleRate metrics.Histogram
 	NewSampleRate  metrics.Histogram
 	RateLimitDrops metrics.Meter
+	BytesSent      metrics.Meter
 	Extra          map[string]string
 }
 
@@ -55,6 +56,7 @@ func New(companyID int, deviceID int, program, version string) *Metrics {
 		OrigSampleRate: metrics.GetOrRegisterHistogram(name("OrigSampleRate"), reg, sample()),
 		NewSampleRate:  metrics.GetOrRegisterHistogram(name("NewSampleRate"), reg, sample()),
 		RateLimitDrops: metrics.GetOrRegisterMeter(name("RateLimitDrops"), reg),
+		BytesSent:      metrics.GetOrRegisterMeter(name("BytesSent"), reg),
 		Extra:          extra,
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -61,7 +61,7 @@ func New(companyID int, deviceID int, program, version string) *Metrics {
 	}
 }
 
-func (m *Metrics) Start(url, email, token string, interval time.Duration, proxy *url.URL) {
+func (m *Metrics) Start(url, email, token string, prefix string, interval time.Duration, proxy *url.URL) {
 	proxyURL := ""
 	if proxy != nil {
 		proxyURL = proxy.String()
@@ -72,7 +72,7 @@ func (m *Metrics) Start(url, email, token string, interval time.Duration, proxy 
 		Registry:           m.reg,
 		FlushInterval:      interval,
 		DurationUnit:       time.Millisecond,
-		Prefix:             "chf",
+		Prefix:             prefix,
 		Debug:              false,
 		Send:               make(chan []byte, MaxHttpRequests),
 		ProxyUrl:           proxyURL,

--- a/send.go
+++ b/send.go
@@ -143,6 +143,8 @@ func (s *Sender) dispatch() {
 		if err != nil {
 			s.error(err)
 			continue
+		} else {
+			s.Metrics.BytesSent.Mark(int64(buf.Len()))
 		}
 	}
 	s.workers.Done()

--- a/send.go
+++ b/send.go
@@ -139,14 +139,15 @@ func (s *Sender) dispatch() {
 		}
 
 		z.Close()
+		l := buf.Len()
 		err = s.client.SendFlow(url, buf)
 		if err != nil {
 			s.error(err)
 			continue
-		} else {
-			if s.Metrics != nil {
-				s.Metrics.BytesSent.Mark(int64(buf.Len()))
-			}
+		}
+
+		if s.Metrics != nil {
+			s.Metrics.BytesSent.Mark(int64(l))
 		}
 	}
 	s.workers.Done()

--- a/send.go
+++ b/send.go
@@ -144,7 +144,9 @@ func (s *Sender) dispatch() {
 			s.error(err)
 			continue
 		} else {
-			s.Metrics.BytesSent.Mark(int64(buf.Len()))
+			if s.Metrics != nil {
+				s.Metrics.BytesSent.Mark(int64(buf.Len()))
+			}
 		}
 	}
 	s.workers.Done()

--- a/send_test.go
+++ b/send_test.go
@@ -34,7 +34,8 @@ func TestSender(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	assert.True(sender.Stop(100 * time.Millisecond))
+	assert.Greater(sender.Metrics.BytesSent.Count(), int64(0))
 	assert.Equal(flowToCHF(expected, t).String(), msgs.At(0).String())
 }
 

--- a/send_test.go
+++ b/send_test.go
@@ -105,6 +105,7 @@ func setup(t testing.TB) (*Sender, *test.Server, *assert.Assertions) {
 
 	url := server.URL(test.FLOW)
 	sender := newSender(url, 1*time.Second)
+	sender.Metrics = metrics
 	sender.start(agg, client, device, 1)
 
 	return sender, server, assert.New(t)


### PR DESCRIPTION
# Overview
This introduces a new meter metric, `client_BytesSent`, to capture the number of successfully sent bytes in the payload of the HTTP POST requests when sending flow data. It also allows setting the metrics prefix to correctly namespace the metrics for different services.

# Validation
Ran on an internal service, both with a specific prefix and validating that the `client_BytesSent` was received with what looks to be approximately correct values. It's important to get the length of the buffer _prior_ to sending it, since this is a buffer that will get drained and the length is reset to 0 on a successful send.

There is also an addition to the existing unit tests to ensure the Bytes Sent metric is properly incremented, but no direct test against setting the prefix since it is a simple setter method.