### PR TITLE
reorder struct fields for compactness

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,21 +17,21 @@ import (
 
 // Config describes the libkflow configuration.
 type Config struct {
-	email   string
-	token   string
-	capture Capture
+	logger  interface{}
+	metrics *url.URL
+	flow    *url.URL
 	proxy   *url.URL
 	api     *url.URL
-	flow    *url.URL
-	metrics *url.URL
-	sample  int
-	timeout time.Duration
-	retries int
-	logger  interface{}
 	program string
+	email   string
+	token   string
 	version string
 
 	metricsPrefix   string
+	capture         Capture
+	sample          int
+	timeout         time.Duration
+	retries         int
 	metricsInterval time.Duration
 }
 

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -17,73 +17,73 @@ type Ckflow C.kflow
 const MAX_CUSTOM_STR_LEN = 384
 
 type Flow struct {
-	TimestampNano      int64
-	DstAs              uint32
-	DstGeo             uint32
-	DstMac             uint32 // IGNORED - use DstEthMac
-	HeaderLen          uint32
-	InBytes            uint64
-	InPkts             uint64
-	InputPort          uint32
-	IpSize             uint32
-	Ipv4DstAddr        uint32
-	Ipv4SrcAddr        uint32
-	L4DstPort          uint32
-	L4SrcPort          uint32
-	OutputPort         uint32
-	Protocol           uint32
-	SampledPacketSize  uint32
-	SrcAs              uint32
-	SrcGeo             uint32
-	SrcMac             uint32 // IGNORED - use SrcEthMac
-	TcpFlags           uint32
-	Tos                uint32
-	VlanIn             uint32
-	VlanOut            uint32
-	Ipv4NextHop        uint32
-	MplsType           uint32
-	OutBytes           uint64
-	OutPkts            uint64
-	TcpRetransmit      uint32
-	AppProtocol        uint32
+	SrcBgpCommunity    string
 	SrcFlowTags        string
 	DstFlowTags        string
-	SampleRate         uint32
-	DeviceId           uint32
 	FlowTags           string
-	Timestamp          int64
 	DstBgpAsPath       string
 	DstBgpCommunity    string
 	SrcBgpAsPath       string
-	SrcBgpCommunity    string
+	Ipv6SrcAddr        []byte
+	Ipv6SrcRoutePrefix []byte
+	Customs            []Custom
+	Ipv6DstRoutePrefix []byte
+	Ipv6DstAddr        []byte
+	Ipv6SrcNextHop     []byte
+	Ipv6DstNextHop     []byte
+	InBytes            uint64
+	InPkts             uint64
+	Timestamp          int64
+	DstEthMac          uint64
+	TimestampNano      int64
+	OutBytes           uint64
+	SrcEthMac          uint64
+	OutPkts            uint64
+	SampleRate         uint32
+	DstThirdAsn        uint32
+	MplsType           uint32
+	VlanOut            uint32
+	VlanIn             uint32
+	TcpRetransmit      uint32
+	AppProtocol        uint32
+	Tos                uint32
+	TcpFlags           uint32
+	SrcMac             uint32 // IGNORED - use SrcEthMac
+	DeviceId           uint32
+	SrcGeo             uint32
+	SrcAs              uint32
+	SampledPacketSize  uint32
+	Protocol           uint32
+	OutputPort         uint32
+	L4SrcPort          uint32
 	SrcNextHopAs       uint32
 	DstNextHopAs       uint32
 	SrcGeoRegion       uint32
 	DstGeoRegion       uint32
 	SrcGeoCity         uint32
 	DstGeoCity         uint32
-	Big                bool
-	SampleAdj          bool
+	DstAs              uint32
+	DstGeo             uint32
 	Ipv4DstNextHop     uint32
 	Ipv4SrcNextHop     uint32
 	SrcRoutePrefix     uint32
 	DstRoutePrefix     uint32
-	SrcRouteLength     uint8
-	DstRouteLength     uint8
+	DstMac             uint32 // IGNORED - use DstEthMac
+	HeaderLen          uint32
 	SrcSecondAsn       uint32
 	DstSecondAsn       uint32
 	SrcThirdAsn        uint32
-	DstThirdAsn        uint32
-	Ipv6DstAddr        []byte
-	Ipv6SrcAddr        []byte
-	SrcEthMac          uint64
-	DstEthMac          uint64
-	Ipv6SrcNextHop     []byte
-	Ipv6DstNextHop     []byte
-	Ipv6SrcRoutePrefix []byte
-	Ipv6DstRoutePrefix []byte
+	Ipv4NextHop        uint32
+	L4DstPort          uint32
+	Ipv4SrcAddr        uint32
+	Ipv4DstAddr        uint32
+	IpSize             uint32
+	InputPort          uint32
+	DstRouteLength     uint8
+	SrcRouteLength     uint8
+	SampleAdj          bool
 	IsMetric           bool
-	Customs            []Custom
+	Big                bool
 }
 
 type Type int
@@ -104,20 +104,20 @@ const (
 )
 
 type Custom struct {
-	ID   uint32
-	Type Type
 	Str  string
-	U8   byte
-	U16  uint16
-	U32  uint32
 	U64  uint64
-	I8   int8
-	I16  int16
-	I32  int32
-	I64  int64
-	F32  float32
+	Type Type
 	F64  float64
+	I64  int64
+	I32  int32
+	U32  uint32
+	ID   uint32
+	F32  float32
+	I16  int16
+	U16  uint16
 	Addr [17]byte
+	I8   int8
+	U8   byte
 }
 
 func New(cflow *Ckflow) Flow {

--- a/send.go
+++ b/send.go
@@ -22,15 +22,15 @@ type Sender struct {
 	agg     *agg.Agg
 	exit    chan struct{}
 	url     *url.URL
-	timeout time.Duration
 	client  *api.Client
-	sample  int
 	ticker  *time.Ticker
-	workers sync.WaitGroup
 	dns     chan []byte
 	Device  *api.Device
 	Errors  chan<- error
 	Metrics *metrics.Metrics
+	workers sync.WaitGroup
+	timeout time.Duration
+	sample  int
 }
 
 func newSender(url *url.URL, timeout time.Duration) *Sender {


### PR DESCRIPTION
reorder struct fields for compactness using https://github.com/dkorunic/betteralign

had to duplicate flow/flow.go to tmp.go to get the tool to pick up the structs:

/Users/rtice/src/gopath/libkflow/tmp.go:3:11: struct of size 520 could be 512
/Users/rtice/src/gopath/libkflow/tmp.go:73:13: struct of size 104 could be 88
/Users/rtice/src/gopath/libkflow/config.go:19:13: struct with 168 pointer bytes could be 136
/Users/rtice/src/gopath/libkflow/send.go:21:13: struct with 104 pointer bytes could be 72

closes #21 