### PR TITLE
add labels for both new and passed-in registry paths

### DIFF
--- a/lib_test.go
+++ b/lib_test.go
@@ -294,21 +294,6 @@ func TestNewSenderFromDevice(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestMetricsConfig(t *testing.T) {
-	dev, assert := setupLibTest(t)
-
-	program := "test"
-	version := "0.0.1"
-
-	config := libkflow.NewConfig(email, token, "test", "0.0.1")
-	metrics := config.NewMetrics(dev)
-
-	assert.Equal(program+"-"+version, metrics.Extra["ver"])
-	assert.Equal(program, metrics.Extra["ft"])
-	assert.Equal("libkflow", metrics.Extra["dt"])
-	assert.Equal("primary", metrics.Extra["level"])
-}
-
 func setupLibTest(t *testing.T) (*api.Device, *assert.Assertions) {
 	client, server, device, err := test.NewClientServer()
 	if err != nil {

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsConfig(t *testing.T) {
+
+	program := "test"
+	version := "0.0.1"
+
+	metrics := New(1, 2, program, version)
+
+	metrics.Unregister()
+
+	metrics.reg.Each(func(name string, _ interface{}) {
+		assert.Contains(t, name, "ver="+program+"-"+version)
+		assert.Contains(t, name, "ft="+program)
+		assert.Contains(t, name, "dt=libkflow")
+		assert.Contains(t, name, "level=primary")
+		assert.Contains(t, name, "cid=1")
+		assert.Contains(t, name, "did=2")
+	})
+}


### PR DESCRIPTION
The alternate path added here https://github.com/kentik/libkflow/pull/26 which enabled creating metrics from a predefined registry did not add the extra labels to the metrics.

This PR unifies both paths to explicitly define metric labels during creation rather than passing in the `Extras` map to the `OpenHTTPTSDBWithConfig` call.