### PR TITLE
TLS handshake timeout override

### DIFF
--- a/agg/agg.go
+++ b/agg/agg.go
@@ -1,7 +1,6 @@
 package agg
 
 import (
-	"log"
 	"sync"
 	"time"
 
@@ -96,8 +95,6 @@ func (a *Agg) aggregate() {
 	for {
 		select {
 		case <-a.ticker.C:
-			log.Printf("agg size %d", a.queue.count)
-			log.Printf("dropped %d", a.queue.dropped)
 			a.dispatch()
 		case <-a.quitting:
 			a.dispatch()

--- a/agg/agg.go
+++ b/agg/agg.go
@@ -1,6 +1,7 @@
 package agg
 
 import (
+	"log"
 	"sync"
 	"time"
 
@@ -95,6 +96,8 @@ func (a *Agg) aggregate() {
 	for {
 		select {
 		case <-a.ticker.C:
+			log.Printf("agg size %d", a.queue.count)
+			log.Printf("dropped %d", a.queue.dropped)
 			a.dispatch()
 		case <-a.quitting:
 			a.dispatch()

--- a/api/client.go
+++ b/api/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -385,7 +384,6 @@ func (c *Client) UpdateInterfacesDirectly(dev *Device, updates map[string]Interf
 func (c *Client) SendFlow(url string, buf *bytes.Buffer) error {
 	r, err := c.do("POST", url, "application/binary", buf, true)
 	if err != nil {
-		log.Printf("error in sendFlow %v", err)
 		return err
 	}
 

--- a/config.go
+++ b/config.go
@@ -18,21 +18,22 @@ import (
 
 // Config describes the libkflow configuration.
 type Config struct {
-	email             string
-	token             string
-	capture           Capture
-	proxy             *url.URL
-	api               *url.URL
-	flow              *url.URL
-	metrics           *url.URL
-	sample            int
-	timeout           time.Duration
-	retries           int
-	logger            interface{}
-	program           string
-	version           string
-	registry          go_metrics.Registry
-	useInternalErrors bool
+	email               string
+	token               string
+	capture             Capture
+	proxy               *url.URL
+	api                 *url.URL
+	flow                *url.URL
+	metrics             *url.URL
+	sample              int
+	timeout             time.Duration
+	tlsHandshakeTimeout time.Duration
+	retries             int
+	logger              interface{}
+	program             string
+	version             string
+	registry            go_metrics.Registry
+	useInternalErrors   bool
 
 	metricsPrefix   string
 	metricsInterval time.Duration
@@ -91,6 +92,11 @@ func (c *Config) SetServer(host net.IP, port int) {
 // SetTimeout sets the HTTP request timeout.
 func (c *Config) SetTimeout(timeout time.Duration) {
 	c.timeout = timeout
+}
+
+// SetTLSHandshakeTimeout sets the TLSHandshakeTimeout on the http client's Transport
+func (c *Config) SetTLSHandshakeTimeout(timeout time.Duration) {
+	c.tlsHandshakeTimeout = timeout
 }
 
 // SetRetries sets the number of times to try HTTP requests.


### PR DESCRIPTION
Currently the http client used to send flow has its`Transport.TLSHandshakeTimeout` set to 10 seconds. In some cases we've seen this time out due to intermittent periods of increased latency. We want to be able to optionally set this timeout to a higher value so we can complete connections.