### PR TITLE
Use the global logger by default, given that it may have been set elsewhere

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,7 +5,6 @@ import (
 	go_log "log"
 	"net"
 	"net/url"
-	"os"
 	"strconv"
 	"time"
 
@@ -234,7 +233,7 @@ func defaultConfig(email, token, program, version string) *Config {
 		metrics:       parseURL("https://flow.kentik.com/tsdb"),
 		timeout:       10 * time.Second,
 		retries:       0,
-		logger:        go_log.New(os.Stderr, "", go_log.LstdFlags), // default behavior of underlying logger
+		logger:        go_log.Default(),
 		program:       program,
 		version:       version,
 		metricsPrefix: "chf",


### PR DESCRIPTION
Some downstream users of the library may have embedded this Go package into other wrapped instances. When they do this, setting the level of the logger is done off of the global logger, so it was not honored by our defaults (that have their own instance). This change should fix the regression caused in https://github.com/kentik/libkflow/commit/cc70a3e90d0827ee9e8fe530f58d56cd295b4f67#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R204 as part of https://github.com/kentik/libkflow/pull/17