### PR TITLE
Adds a `SendFlows()` message to the sender for synchronous usage

### DIFF
--- a/agg/agg.go
+++ b/agg/agg.go
@@ -123,7 +123,7 @@ func (a *Agg) dispatch() {
 	}
 
 	// adjust the sample rate for the provided flows
-	normalizeSampleRate(flows, resampleRateAdj)
+	flow.NormalizeSampleRate(flows, resampleRateAdj)
 
 	// serialize the data using the provided segment (backed by msg)
 	message, err := flow.ToCapnProtoMessage(flows, seg)
@@ -141,22 +141,5 @@ func (a *Agg) error(err error) {
 	select {
 	case a.errors <- err:
 	default:
-	}
-}
-
-// normalizeSampleRate adjusts the sample rate in place on the provided [flow.Flow] slice based on a provided
-// adjustment factor if it is > 1.0. The adjustment factor is multiplied by the original sample rate and 100 to get
-// the new sample rate, as it is expected that a [flow.Flow] with a sample rate that does not account for this change.
-func normalizeSampleRate(flows []flow.Flow, resampleRateAdj float32) {
-	for i := range flows {
-		sampleRate := flows[i].SampleRate
-		adjustedSR := sampleRate * 100
-
-		if resampleRateAdj > 1.0 {
-			adjustedSR = uint32(float32(adjustedSR) * resampleRateAdj)
-		}
-
-		flows[i].SampleAdj = true
-		flows[i].SampleRate = adjustedSR
 	}
 }

--- a/agg/agg.go
+++ b/agg/agg.go
@@ -134,7 +134,7 @@ func (a *Agg) dispatch() {
 
 	a.output <- message
 
-	a.metrics.TotalFlowsOut.Mark(int64(count))
+	a.metrics.TotalFlowsOut.Mark(int64(len(flows)))
 }
 
 func (a *Agg) error(err error) {

--- a/agg/agg_test.go
+++ b/agg/agg_test.go
@@ -7,10 +7,11 @@ import (
 
 	capnp "zombiezen.com/go/capnproto2"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kentik/libkflow/chf"
 	"github.com/kentik/libkflow/flow"
 	"github.com/kentik/libkflow/metrics"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAggSimple(t *testing.T) {
@@ -68,8 +69,6 @@ func setup(t *testing.T, interval time.Duration, fps int) (*testState, *assert.A
 	metrics := &metrics.Metrics{
 		TotalFlowsIn:   metrics.NewMeter(),
 		TotalFlowsOut:  metrics.NewMeter(),
-		OrigSampleRate: metrics.NewHistogram(metrics.NewUniformSample(100)),
-		NewSampleRate:  metrics.NewHistogram(metrics.NewUniformSample(100)),
 		RateLimitDrops: metrics.NewMeter(),
 		BytesSent:      metrics.NewMeter(),
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -383,7 +383,7 @@ func (c *Client) SendFlow(url string, buf *bytes.Buffer) error {
 	}
 
 	defer r.Body.Close()
-	io.Copy(io.Discard, r.Body)
+	_, _ = io.Copy(io.Discard, r.Body)
 
 	if r.StatusCode != 200 {
 		return fmt.Errorf("api: HTTP status code %d", r.StatusCode)

--- a/api/client.go
+++ b/api/client.go
@@ -376,6 +376,8 @@ func (c *Client) UpdateInterfacesDirectly(dev *Device, updates map[string]Interf
 	return nil
 }
 
+// SendFlow sends the provided buffer containing a gzipped, cap'n proto packed, representation of flows to the provided
+// url.
 func (c *Client) SendFlow(url string, buf *bytes.Buffer) error {
 	r, err := c.do("POST", url, "application/binary", buf, true)
 	if err != nil {

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -262,7 +262,7 @@ func (f *Flow) FillCHF(kflow chf.CHF, list chf.Custom_List) {
 
 	for i, c := range f.Customs {
 		kc := list.At(i)
-		kc.SetId(uint32(c.ID))
+		kc.SetId(c.ID)
 
 		switch c.Type {
 		case Str:

--- a/flow/sampling.go
+++ b/flow/sampling.go
@@ -1,0 +1,18 @@
+package flow
+
+// NormalizeSampleRate adjusts the sample rate in place on the provided [flow.Flow] slice based on a provided
+// adjustment factor if it is > 1.0. The adjustment factor is multiplied by the original sample rate and 100 to get
+// the new sample rate, as it is expected that a [flow.Flow] with a sample rate that does not account for this change.
+func NormalizeSampleRate(flows []Flow, resampleRateAdj float32) {
+	for i := range flows {
+		sampleRate := flows[i].SampleRate
+		adjustedSR := sampleRate * 100
+
+		if resampleRateAdj > 1.0 {
+			adjustedSR = uint32(float32(adjustedSR) * resampleRateAdj)
+		}
+
+		flows[i].SampleAdj = true
+		flows[i].SampleRate = adjustedSR
+	}
+}

--- a/flow/serialization.go
+++ b/flow/serialization.go
@@ -1,0 +1,39 @@
+package flow
+
+import (
+	"fmt"
+
+	capnp "zombiezen.com/go/capnproto2"
+
+	"github.com/kentik/libkflow/chf"
+)
+
+// ToCapnProtoMessage converts a slice of Flow objects into a Cap'n Proto message.
+func ToCapnProtoMessage(flows []Flow, segment *capnp.Segment) (*capnp.Message, error) {
+	packedCHF, err := chf.NewRootPackedCHF(segment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create root packed CHF: %w", err)
+	}
+
+	chfList, err := packedCHF.NewMsgs(int32(len(flows)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create messages list: %w", err)
+	}
+
+	for i, f := range flows {
+		var list chf.Custom_List
+		if n := int32(len(f.Customs)); n > 0 {
+			list, err = chf.NewCustom_List(segment, n)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create custom list: %w", err)
+			}
+		}
+		f.FillCHF(chfList.At(i), list)
+	}
+
+	err = packedCHF.SetMsgs(chfList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set messages: %w", err)
+	}
+	return segment.Message(), nil
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -20,8 +20,6 @@ type Metrics struct {
 	reg            metrics.Registry
 	TotalFlowsIn   metrics.Meter
 	TotalFlowsOut  metrics.Meter
-	OrigSampleRate metrics.Histogram
-	NewSampleRate  metrics.Histogram
 	RateLimitDrops metrics.Meter
 	BytesSent      metrics.Meter
 }
@@ -35,18 +33,12 @@ func New(companyID int, deviceID int, program, version string) *Metrics {
 
 // NewWithRegistry returns a new Metrics but allows a specific registry to be used rather than creating a new one
 func NewWithRegistry(reg metrics.Registry, companyID int, deviceID int, program, version string) *Metrics {
-	sample := func() metrics.Sample {
-		return metrics.NewExpDecaySample(MetricsSampleSize, MetricsSampleAlpha)
-	}
-
 	suffix := fmt.Sprintf("^ver=%s^ft=%s^dt=%s^level=%s^cid=%s^did=%s", program+"-"+version, program, "libkflow", "primary", strconv.Itoa(companyID), strconv.Itoa(deviceID))
 
 	return &Metrics{
 		reg:            reg,
 		TotalFlowsIn:   metrics.GetOrRegisterMeter("client_Total"+suffix, reg),
 		TotalFlowsOut:  metrics.GetOrRegisterMeter("client_DownsampleFPS"+suffix, reg),
-		OrigSampleRate: metrics.GetOrRegisterHistogram("client_OrigSampleRate"+suffix, reg, sample()),
-		NewSampleRate:  metrics.GetOrRegisterHistogram("client_NewSampleRate"+suffix, reg, sample()),
 		RateLimitDrops: metrics.GetOrRegisterMeter("client_RateLimitDrops"+suffix, reg),
 		BytesSent:      metrics.GetOrRegisterMeter("client_BytesSent"+suffix, reg),
 	}

--- a/send.go
+++ b/send.go
@@ -66,6 +66,9 @@ func (s *Sender) Send(flow *flow.Flow) {
 // the flows is set to the device ID of the sender, regardless of what it was previously set to. This is to ensure all
 // data matches the expectations of the downstream URL/API.
 func (s *Sender) SendFlows(flows []flow.Flow) (int64, error) {
+	s.workers.Add(1)
+	defer s.workers.Done()
+
 	if s.Device == nil {
 		return 0, fmt.Errorf("device not initialized")
 	}

--- a/send.go
+++ b/send.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kentik/libkflow/metrics"
 )
 
+// messagePrefix is an 80-byte prefix for the message header when sending kflow to the Kentik API. This is a deprecated
+// header, but the bytes must remain for backwards compatibility with the Kentik API.
 var messagePrefix = [80]byte{}
 
 // A Sender aggregates and transmits flow information to Kentik.

--- a/send.go
+++ b/send.go
@@ -62,7 +62,9 @@ func (s *Sender) Send(flow *flow.Flow) {
 	s.agg.Add(flow)
 }
 
-// SendFlows sends the flows to the Kentik API, returning the number of bytes sent as the payload.
+// SendFlows sends the flows to the Kentik API, returning the number of bytes sent as the payload. The device ID on
+// the flows is set to the device ID of the sender, regardless of what it was previously set to. This is to ensure all
+// data matches the expectations of the downstream URL/API.
 func (s *Sender) SendFlows(flows []flow.Flow) (int64, error) {
 	if s.Device == nil {
 		return 0, fmt.Errorf("device not initialized")


### PR DESCRIPTION
# Overview
Adds a `SendFlows()` receiver function on the `Sender` so that callers can perform an synchronous call to send the flows, rather than depending on an asynchronous queuing of the flow.

# Description
Beyond adding in the new receiver function, this breaks out some existing logic into helper functions for re-use and better documentation. Specifically this breaks out

- Normalizing of Sample Rates
- Serialization from `flow.Flow` to the Cap'n Proto message that can be serialized to the wire
- Breaking out the "message prefix" with comments on why it exists

In doing this, I also spotted that adjusting the sampling rating was potentially flawed as it would just take the _last_ sample rate applied. If the flow is heterogenous, which is often may be, then this is a sample rate off of a sample of data... which is a bit odd and incorrect. We've removed and/or changed this metric elsewhere in our internal libraries so I'm removing it here as it no longer provides value.

## Bug Fix on URL
The provided `*url.URL` to the `Sender` was modified in place. This means the backing `*url.URL` in the configuration changed each time a new sender was brought online by the same config. This is _ok_ because each one copies in their own URL settings... but is ultimately a bug because the sender shouldn't be modifying the configuration. I fixed this by creating a new copy of the URL to be used and to avoid modifying the underlying/backing object.

# Validation
Added a unit test to validate expected behavior. Additional integration and functional testing will be done against internal services to verify expected behavior continues to work and the new function also works as expected.

We also tested this within two internal services and it looks like it's working as expected.